### PR TITLE
reorder media queries, remove redundant css properties on hero__figur…

### DIFF
--- a/main.css
+++ b/main.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,100..900;1,9..144,100..900&family=Manrope:wght@200..800&display=swap");
+@import url('https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,100..900;1,9..144,100..900&family=Manrope:wght@200..800&display=swap');
 
 /* || REST */
 * {
@@ -23,8 +23,8 @@ img {
   --WHITE: #fff;
 
   /* TYPOGRAPHY */
-  --FF1: "Manrope", sans-serif;
-  --FF2: "Fraunces", serif;
+  --FF1: 'Manrope', sans-serif;
+  --FF2: 'Fraunces', serif;
   --FW-SEMI-BOLD: 600;
   --TEXT-PRESET1: var(--FW-SEMI-BOLD) 5rem/100% var(--FF2);
   --TEXT-PRESET2: var(--FW-SEMI-BOLD) 3.5rem/120% var(--FF2);
@@ -124,7 +124,7 @@ h3 {
   width: auto;
   height: 771px;
   top: 0;
-  background-image: url("./images/ornamental.svg");
+  background-image: url('./images/ornamental.svg');
   background-repeat: no-repeat;
   background-position: bottom;
   background-size: 100%;
@@ -183,7 +183,7 @@ h3 {
 /* || MAIN-VALUE */
 .article__value {
   padding: 88px 160px 144px 160px;
-  background-image: url("./images/ornamental-2.svg");
+  background-image: url('./images/ornamental-2.svg');
   background-repeat: no-repeat;
   background-position: bottom;
   background-size: 100%;
@@ -352,191 +352,10 @@ h3 {
   gap: 28px;
 }
 
+/* REORDER MEDIA QUERIES */
 /* || MEDIA QUERIES */
-/* Smartphone breakpoint */
-@media screen and (min-width: 375px) {
-  body {
-    overflow-x: hidden;
-  }
 
-  /*||HEADER */
-  .header {
-    height: 481px;
-    max-width: 100%;
-  }
-
-  .nav ul {
-    padding: 32px 20px;
-  }
-
-  .hero {
-    max-width: 100%;
-    height: 481px; /* Ensures the hero section covers the full viewport height */
-  }
-
-  .hero__title {
-    font-weight: var(--FW-SEMI-BOLD);
-    font-size: 2.5rem;
-    color: var(--WHITE);
-  }
-
-  .hero__cta__button {
-    width: 151px;
-    height: 53px;
-  }
-
-  .hero__figure__left {
-    display: none;
-  }
-
-  .hero__figure__right {
-    display: none;
-  }
-
-  .hero__figure__main img {
-    margin-top: 64px;
-    margin-left: auto;
-    margin-right: auto;
-    height: 184px;
-    width: 320px;
-  }
-
-  /* || MAIN-VALUE */
-  .article__value {
-    padding: 64px 20px;
-    margin-top: 64px;
-  }
-
-  .section__value {
-    gap: 24px;
-  }
-
-  .section__value__marker {
-    font-size: 1.25rem;
-    width: 48px;
-    height: 48px;
-  }
-
-  .section__value__h3 {
-    font-size: 1.5rem;
-    font-family: var(--FF2);
-    font-weight: var(--FW-SEMI-BOLD);
-    margin-bottom: 16px;
-  }
-
-  .section__value__p {
-    font: var(--TEXT-PRESET4);
-    color: var(--PURPLE-900);
-  }
-
-  .article__value {
-    display: flex;
-    flex-flow: column;
-    gap: 32px;
-  }
-
-  /* || MAIN-CTA */
-  .article__cta {
-    padding-bottom: 80px;
-  }
-
-  .card-wrapper {
-    width: 335px;
-    height: 625px;
-    padding: 112px 20px 0px 20px;
-  }
-
-  .card {
-    position: absolute;
-  }
-
-  .card-bottom {
-    z-index: 1;
-  }
-
-  .card-top {
-    z-index: 2;
-    top: 344px;
-    left: 0px;
-  }
-
-  .headshot__container {
-    width: 280px;
-    height: 280px;
-  }
-
-  .headshot__container img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    border-radius: 50%;
-  }
-
-  .section__cta-content {
-    padding: 32px;
-    background-color: var(--PURPLE-900);
-    width: 335px;
-    height: 393px;
-    justify-content: center;
-    align-items: center;
-  }
-
-  .section__cta-content__h2 {
-    font-size: 2rem;
-    font-weight: var(--FW-SEMI-BOLD);
-    font-family: var(--FF2);
-    line-height: 120%;
-  }
-
-  .section__cta-content p {
-    font-size: 1rem;
-    font-weight: normal;
-    font-family: var(--FF1);
-    line-height: 180%;
-  }
-
-  .section__cta__button {
-    width: 207px;
-    height: 56px;
-    background-color: var(--GREEN);
-    display: grid;
-    place-items: center;
-    color: var(--PURPLE-900);
-    font: var(--TEXT-PRESET5);
-  }
-
-  .section__figure__cta {
-    display: none;
-  }
-
-  /* || FOOTER */
-  .footer {
-    padding: 80px;
-    background-color: var(--WHITE);
-    display: flex;
-    flex-flow: column;
-    align-items: center;
-    gap: 56px;
-    max-width: 100%;
-    height: 262px;
-  }
-
-  .section__footer__social-links figure img {
-    max-width: 20px;
-    height: 20px;
-  }
-
-  .footer__figure figure img {
-    max-width: 97.55px;
-    height: 25px;
-  }
-
-  .section__footer__social-links {
-    display: flex;
-    gap: 28px;
-  }
-}
-
+/* max-width: 360px comes first */
 @media screen and (max-width: 360px) {
   body {
     overflow-x: hidden;
@@ -719,6 +538,8 @@ h3 {
     gap: 28px;
   }
 }
+
+/* min-width: 344px comes second */
 @media screen and (min-width: 344px) {
   body {
     overflow-x: hidden;
@@ -902,7 +723,193 @@ h3 {
   }
 }
 
+/* Smartphone breakpoint */
+/* min-width: 375px comes second */
+@media screen and (min-width: 375px) {
+  body {
+    overflow-x: hidden;
+  }
+
+  /*||HEADER */
+  .header {
+    height: 481px;
+    max-width: 100%;
+  }
+
+  .nav ul {
+    padding: 32px 20px;
+  }
+
+  .hero {
+    max-width: 100%;
+    height: 481px; /* Ensures the hero section covers the full viewport height */
+  }
+
+  .hero__title {
+    font-weight: var(--FW-SEMI-BOLD);
+    font-size: 2.5rem;
+    color: var(--WHITE);
+  }
+
+  .hero__cta__button {
+    width: 151px;
+    height: 53px;
+  }
+
+  .hero__figure__left {
+    display: none;
+  }
+
+  .hero__figure__right {
+    display: none;
+  }
+
+  .hero__figure__main img {
+    margin-top: 64px;
+    margin-left: auto;
+    margin-right: auto;
+    height: 184px;
+    width: 320px;
+  }
+
+  /* || MAIN-VALUE */
+  .article__value {
+    padding: 64px 20px;
+    margin-top: 64px;
+  }
+
+  .section__value {
+    gap: 24px;
+  }
+
+  .section__value__marker {
+    font-size: 1.25rem;
+    width: 48px;
+    height: 48px;
+  }
+
+  .section__value__h3 {
+    font-size: 1.5rem;
+    font-family: var(--FF2);
+    font-weight: var(--FW-SEMI-BOLD);
+    margin-bottom: 16px;
+  }
+
+  .section__value__p {
+    font: var(--TEXT-PRESET4);
+    color: var(--PURPLE-900);
+  }
+
+  .article__value {
+    display: flex;
+    flex-flow: column;
+    gap: 32px;
+  }
+
+  /* || MAIN-CTA */
+  .article__cta {
+    padding-bottom: 80px;
+  }
+
+  .card-wrapper {
+    width: 335px;
+    height: 625px;
+    padding: 112px 20px 0px 20px;
+  }
+
+  .card {
+    position: absolute;
+  }
+
+  .card-bottom {
+    z-index: 1;
+  }
+
+  .card-top {
+    z-index: 2;
+    top: 344px;
+    left: 0px;
+  }
+
+  .headshot__container {
+    width: 280px;
+    height: 280px;
+  }
+
+  .headshot__container img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 50%;
+  }
+
+  .section__cta-content {
+    padding: 32px;
+    background-color: var(--PURPLE-900);
+    width: 335px;
+    height: 393px;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .section__cta-content__h2 {
+    font-size: 2rem;
+    font-weight: var(--FW-SEMI-BOLD);
+    font-family: var(--FF2);
+    line-height: 120%;
+  }
+
+  .section__cta-content p {
+    font-size: 1rem;
+    font-weight: normal;
+    font-family: var(--FF1);
+    line-height: 180%;
+  }
+
+  .section__cta__button {
+    width: 207px;
+    height: 56px;
+    background-color: var(--GREEN);
+    display: grid;
+    place-items: center;
+    color: var(--PURPLE-900);
+    font: var(--TEXT-PRESET5);
+  }
+
+  .section__figure__cta {
+    display: none;
+  }
+
+  /* || FOOTER */
+  .footer {
+    padding: 80px;
+    background-color: var(--WHITE);
+    display: flex;
+    flex-flow: column;
+    align-items: center;
+    gap: 56px;
+    max-width: 100%;
+    height: 262px;
+  }
+
+  .section__footer__social-links figure img {
+    max-width: 20px;
+    height: 20px;
+  }
+
+  .footer__figure figure img {
+    max-width: 97.55px;
+    height: 25px;
+  }
+
+  .section__footer__social-links {
+    display: flex;
+    gap: 28px;
+  }
+}
+
 /* Tablet breakpoint */
+/* min-width: 768px and max-width: 1024px comes last */
 @media screen and (min-width: 768px) and (max-width: 1024px) {
   body {
     overflow-x: hidden;
@@ -920,7 +927,7 @@ h3 {
 
   .hero {
     max-width: 100%;
-    height: 540px; 
+    height: 540px;
   }
 
   .hero__title {
@@ -934,16 +941,10 @@ h3 {
     height: 56px;
   }
 
-  .hero__figure__left {
-    position: absolute;
-    top: 138px;
-    left: -218px;
-  }
-
+  /* Remove Redundant position, top and left properties and set display back to block */
+  .hero__figure__left,
   .hero__figure__right {
-    position: absolute;
-    top: 342px;
-    right: -96px;
+    display: block; /* Reset the display property */
   }
 
   .hero__figure__main img {


### PR DESCRIPTION
changed the media queries orders from:

@media screen and (min-width: 375px) {}
@media screen and (max-width: 360px) {}
@media screen and (min-width: 344px) {}
@media screen and (min-width: 768px) and (max-width: 1024px) {}

To:
@media screen and (max-width: 360px) {}
@media screen and (min-width: 344px) {}
@media screen and (min-width: 375px) {}
@media screen and (min-width: 768px) and (max-width: 1024px) {}

made the .hero__figure__left and .hero__figure__right elements visible again in the min-width: 768px and max-width: 1024px media query.  by setting their display property back to block, and removed redundant position, top and right properties